### PR TITLE
Make workarround for empty urls and attachment

### DIFF
--- a/apsi_innovations/templates/innovations/details.html
+++ b/apsi_innovations/templates/innovations/details.html
@@ -2,7 +2,7 @@
 {% load bootstrap_tags %}
 {% load user_tags %}
 {% block content %}
-{% load innovation_tags %}
+    {% load innovation_tags %}
 
     {% if innovation %}
 
@@ -42,28 +42,33 @@
                     {% endfor %}
                     {% if innovation.attachments.all %}
 
-                    <p><h4>Links:</h4></p>
+                        <p><h4>Links:</h4></p>
                         <p>
                             {% for attachment in innovation.urls.all %}
-								<a href='{{ attachment.url }}'>{{ attachment.url }}</a>
-							{% endfor %}
+                                {% if attachment.url %}
+                                    <a href='{{ attachment.url }}'>{{ attachment.url }}</a>
+                                {% endif %}
+                            {% endfor %}
                         </p>
-                    <p><h4>Attachments: </h4> </p>
-						<p>
-							{% for attachment in innovation.attachments.all %}
-								<a href='{{ attachment.file.url }}' class="btn btn-success">{{ attachment.filename }}</a>
-							{% endfor %}
-						</p>
-                    <p><b><h4>Grade:</h4>
-                    {{ innovation.grade }} </b></p>
+                        <p><h4>Attachments: </h4> </p>
+                        <p>
+                            {% for attachment in innovation.attachments.all %}
+                                {% if attachment.filename %}
+                                    <a href='{{ attachment.file.url }}'
+                                       class="btn btn-success">{{ attachment.filename }}</a>
+                                {% endif %}
+                            {% endfor %}
+                        </p>
+                        <p><b><h4>Grade:</h4>
+                            {{ innovation.grade }} </b></p>
 
-					{% endif %}
+                    {% endif %}
 
                     {% if request.user|has_group:"administrators" %}
-                    <p><h4>Student grade weight:</h4>
-                    {{ innovation.student_grade_weight }} </p>
-                    <p><h4>Committee grade weight:</h4>
-                    {{ innovation.employee_grade_weight }} </p>
+                        <p><h4>Student grade weight:</h4>
+                        {{ innovation.student_grade_weight }} </p>
+                        <p><h4>Committee grade weight:</h4>
+                        {{ innovation.employee_grade_weight }} </p>
                     {% endif %}
                 </div>
                 <div class="panel-footer">
@@ -133,9 +138,9 @@
 
         <h3>Comments:</h3>
         <form action="{% url "innovation_comment" innovation.id %}" method="post" enctype="multipart/form-data">
-        {% csrf_token %}
-        {{ form|as_bootstrap }}
-        <button type="submit" class="btn btn-primary">Add Comment!</button>
+            {% csrf_token %}
+            {{ form|as_bootstrap }}
+            <button type="submit" class="btn btn-primary">Add Comment!</button>
         </form>
         <br/>
 
@@ -144,7 +149,9 @@
                 <div class="panel panel-default">
                     <div class="panel-heading">
                         {{ comment.issuer }}
-                         <p class="pull-right"><small><i>{{ comment.timestamp }}</i></small></p>
+                        <p class="pull-right">
+                            <small><i>{{ comment.timestamp }}</i></small>
+                        </p>
                     </div>
                     <div class="panel-body">
                         {{ comment.text }}
@@ -154,8 +161,8 @@
         {% else %}
             <p>No comments yet.</p>
         {% endif %}
-        {% if comments  %}
-        <h3>Grade history:</h3>
+        {% if comments %}
+            <h3>Grade history:</h3>
             {% for grade in comments %}
                 <div class="panel panel-default">
                     <div class="panel-heading">


### PR DESCRIPTION
During adding new innovations without providing url or attachment
still new objects are created. Those objects are empty and leads to
crashing server during rendering.